### PR TITLE
HUD: Add /scr_sbar_drawarmor666 to be like /hud_armor_pent_666 for old hud

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -17791,6 +17791,16 @@
         }
       ]
     },
+    "scr_sbar_drawarmor666": {
+      "group-id": "47",
+      "desc": "Turns on/off drawing of armor as 666 when holding pent.",
+      "remarks": "This variable applies for old HUD <= 'scr_newhud 0'.",
+      "type": "boolean",
+      "values": [
+        { "name": "false", "description": "Do not draw armor as 666 and instead draw current armor value." },
+        { "name": "true", "description": "Draw armor as 666." }
+      ]
+    },
     "scr_sbar_drawarmoricon": {
       "default": "1",
       "desc": "Turns drawing of armor icon on/off.",

--- a/sbar.c
+++ b/sbar.c
@@ -75,6 +75,7 @@ cvar_t  sbar_drawitems      = {"scr_sbar_drawitems",        "1"};
 cvar_t  sbar_drawsigils     = {"scr_sbar_drawsigils",       "1"};
 cvar_t  sbar_drawhealth     = {"scr_sbar_drawhealth",       "1"};
 cvar_t  sbar_drawarmor      = {"scr_sbar_drawarmor",        "1"};
+cvar_t  sbar_drawarmor666   = {"scr_sbar_drawarmor666",     "1"};
 cvar_t  sbar_drawammo       = {"scr_sbar_drawammo",         "1"};
 cvar_t  sbar_lowammo        = {"scr_sbar_lowammo",          "5"};
 
@@ -296,6 +297,7 @@ void Sbar_Init(void)
 	Cvar_Register(&sbar_drawsigils);
 	Cvar_Register(&sbar_drawhealth);
 	Cvar_Register(&sbar_drawarmor);
+	Cvar_Register(&sbar_drawarmor666);
 	Cvar_Register(&sbar_drawammo);
 	Cvar_Register(&sbar_lowammo);
 	Cvar_Register(&hud_centerranking);
@@ -1000,7 +1002,7 @@ static void Sbar_DrawNormal (void)
 		Sbar_DrawPic (0, 0, sb_sbar);
 
 	// armor
-	if (cl.stats[STAT_ITEMS] & IT_INVULNERABILITY)	{
+	if ((cl.stats[STAT_ITEMS] & IT_INVULNERABILITY) && sbar_drawarmor666.value)	{
 		if (sbar_drawarmor.value)
 			Sbar_DrawNum (24, 0, 666, 3, 1);
 		if (sbar_drawarmoricon.value)
@@ -1060,7 +1062,7 @@ static void Sbar_DrawCompact_WithIcons(void) {
 	old_sbar_xofs = sbar_xofs;
 	sbar_xofs = scr_centerSbar.value ? (vid.width - 158) >> 1: 0;
 
-	if (cl.stats[STAT_ITEMS] & IT_INVULNERABILITY)
+	if ((cl.stats[STAT_ITEMS] & IT_INVULNERABILITY) && sbar_drawarmor666.value)
 		Sbar_DrawNum (2, 0, 666, 3, 1);
 	else
 		Sbar_DrawNum (2, 0, cl.stats[STAT_ARMOR], 3, cl.stats[STAT_ARMOR] <= 25);
@@ -1104,7 +1106,7 @@ static void Sbar_DrawCompact(void) {
 	old_sbar_xofs = sbar_xofs;
 	sbar_xofs = scr_centerSbar.value ? (vid.width - 306) >> 1: 0;
 
-	if (cl.stats[STAT_ITEMS] & IT_INVULNERABILITY)
+	if ((cl.stats[STAT_ITEMS] & IT_INVULNERABILITY) && sbar_drawarmor666.value)
 		Sbar_DrawNum (2, 0, 666, 3, 1);
 	else
 		Sbar_DrawNum (2, 0, cl.stats[STAT_ARMOR], 3, cl.stats[STAT_ARMOR] <= 25);
@@ -1141,7 +1143,7 @@ static void Sbar_DrawCompact_TF(void) {
 	sbar_xofs = scr_centerSbar.value ? (vid.width - 222) >> 1: 0;
 
 	align = scr_compactHudAlign.value ? 1 : 0;
-	if (cl.stats[STAT_ITEMS] & IT_INVULNERABILITY)
+	if ((cl.stats[STAT_ITEMS] & IT_INVULNERABILITY) && sbar_drawarmor666.value)
 		Sbar_DrawNum (2, 0, 666, 3, 1);
 	else
 		Sbar_DrawNum (2, 0, cl.stats[STAT_ARMOR], 3, cl.stats[STAT_ARMOR] <= 25);
@@ -1165,7 +1167,7 @@ static void Sbar_DrawCompact_Bare (void) {
 	old_sbar_xofs = sbar_xofs;
 	sbar_xofs = scr_centerSbar.value ? (vid.width - 158) >> 1: 0;
 
-	if (cl.stats[STAT_ITEMS] & IT_INVULNERABILITY)
+	if ((cl.stats[STAT_ITEMS] & IT_INVULNERABILITY) && sbar_drawarmor666.value)
 		Sbar_DrawNum (2, 0, 666, 3, 1);
 	else
 		Sbar_DrawNum (2, 0, cl.stats[STAT_ARMOR], 3, cl.stats[STAT_ARMOR] <= 25);


### PR DESCRIPTION
Defaults to `1` to not change existing behavior.

`/scr_sbar_drawarmor666 1` (default) with pent:

![1](https://user-images.githubusercontent.com/11351/98204791-8e640700-1eeb-11eb-8070-705f57b996ba.png)

`/scr_sbar_drawarmor666 0` with pent:

![0](https://user-images.githubusercontent.com/11351/98204786-8b691680-1eeb-11eb-985f-b80453e318be.png)
