### PR TITLE
AUTOSHOWNICK: Auto shownick on teammates in point

### DIFF
--- a/cl_main.c
+++ b/cl_main.c
@@ -2545,6 +2545,8 @@ void CL_Frame(double time)
 	R_ParticleEndFrame();
 
 	CL_UpdateCaption(false);
+
+	TP_AutoShowNick();
 }
 
 //============================================================================

--- a/help_variables.json
+++ b/help_variables.json
@@ -1044,6 +1044,26 @@
       "group-id": "9",
       "type": "float"
     },
+    "cl_autoshownick": {
+      "default": "0",
+      "desc": "Enable / disable automatically triggering shownick on teammates if they are in your crosshairs.",
+      "group-id": "8",
+      "type": "integer",
+      "values": [
+        {
+          "description": "No auto shownick.",
+          "name": "0"
+        },
+        {
+          "description": "Trigger `/shownick` when teammate is in crosshairs.",
+          "name": "1"
+        },
+        {
+          "description": "Trigger `/shownick 1` when teammate is in crosshairs.",
+          "name": "2"
+        }
+      ]
+    },
     "cl_backpackfilter": {
       "default": "0",
       "group-id": "8",

--- a/teamplay.h
+++ b/teamplay.h
@@ -235,3 +235,5 @@ void TP_LocFiles_NewMap(void);
 void TP_LocFiles_Shutdown(void);
 
 char *TP_ItemName(int item_flag);
+
+void TP_AutoShowNick(void);


### PR DESCRIPTION
Automatically perform shownick on teammates in crosshairs.

* `/cl_autoshownick 0` (default) - do nothing
* `/cl_autoshownick 1` - when teammate in crosshair execute `cmd shownick`
* `/cl_autoshownick 2` - when teammate in crosshair execute `cmd shownick 1`
