### PR TITLE
Implemented cl_easyaircontrol

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1636,6 +1636,13 @@
       "remarks": "Sign of the value is ignored.",
       "type": "float"
     },
+    "cl_easyaircontrol": {
+      "default": "0",
+      "desc": "When greater than 0, this modifies your input keys held\nto make air control beeline to your held direction.",
+      "group-id": "9",
+      "remarks": "Only useful at values of 0 or [45-90], recommend 62.5 if not 0.",
+      "type": "float"
+    },
     "cl_fp_messages": {
       "default": "4",
       "desc": "This variable is used in conjunction with the variable \"cl_fp_persecond\" to define when the floodprot protection should be triggered (if \"cl_floodprot\" is set to \"1\").",

--- a/src/cl_easyaircontrol.h
+++ b/src/cl_easyaircontrol.h
@@ -1,0 +1,82 @@
+// Logic that modifies the usercmd_t's cmd->forwardmove and cmd->sidemove to make air control easy.
+
+#include "quakedef.h"
+
+cvar_t cl_easyaircontrol = { "cl_easyaircontrol", "0" };
+
+// Function to rotate a 2D vector (x, y) by an angle in degrees
+void rotateVector(float* x, float* y, float angle)
+{
+	float rad = angle * (M_PI / 180);  // Convert angle to radians
+	float x_new = *x * cosf(rad) - *y * sinf(rad);
+	float y_new = *x * sinf(rad) + *y * cosf(rad);
+	*x = x_new;
+	*y = y_new;
+}
+
+void CL_EasyAirControl(usercmd_t* cmd)
+{
+	vec3_t wishdir;
+	float wishdiff, rotateAmount;
+	float velocityX = cl.simvel[0];
+	float velocityY = cl.simvel[1];
+	float playerYaw = cl.simangles[1];
+
+	// Normalize playerYaw to be between -180 and 180 degrees
+	//playerYaw = fmodf(playerYaw + 180.0f, 360.0f) - 180.0f;
+	while (playerYaw > 180) playerYaw -= 360;
+	while (playerYaw < -180) playerYaw += 360;
+
+	wishdir[0] = cmd->forwardmove;
+	wishdir[1] = -1 * cmd->sidemove; // sidemove points right, but positive velocityY points left.
+
+	rotateVector(&wishdir[0], &wishdir[1], playerYaw);
+
+	float velocityMagnitude = sqrt(velocityX * velocityX + velocityY * velocityY);
+	if (velocityMagnitude < 30.0f || (fabsf((wishdir)[0]) < 0.1f && fabsf((wishdir)[1]) < 0.1f))
+		return;
+
+	// Calculate wishdiff
+	float wishdirYaw = atan2f((wishdir)[1], (wishdir)[0]) * (180.0f / M_PI);
+	float velocityYaw = atan2f(velocityY, velocityX) * (180.0f / M_PI);
+	wishdiff = wishdirYaw - velocityYaw;
+
+	// Normalize wishdiff to be between -180 and 180 degrees
+	//wishdiff = fmodf(wishdiff + 180.0f, 360.0f) - 180.0f;
+	while (wishdiff > 180) wishdiff -= 360;
+	while (wishdiff < -180) wishdiff += 360;
+
+	// Give a small deadzone
+	if (fabs(wishdiff) < 2)
+		return;
+
+	// Check if the absolute value of WishDiff is less than the user config cl_easyaircontrol.value
+	if (fabs(wishdiff) < cl_easyaircontrol.value)
+		rotateAmount = 90.0f; // if so, we're giving optimal speed gain in the desired direction
+	else
+	{
+		// otherwise, we're overturning (relative to how far we are past the user config value)
+		float ratio = (fabs(wishdiff) - cl_easyaircontrol.value) / (180.0f - cl_easyaircontrol.value);
+		rotateAmount = 90.0f + (90.0f * ratio);
+	}
+
+	// set the direction accordingly
+	if (wishdiff < 0.0f)
+		rotateAmount *= -1.0f;
+
+	// 
+	// Rotate velocity by rotateAmount, unrotate per player yaw, then normalize it
+	rotateVector(&velocityX, &velocityY, rotateAmount);
+	rotateVector(&velocityX, &velocityY, -1.0f * playerYaw);
+
+	float magnitude = sqrtf(velocityX * velocityX + velocityY * velocityY);
+	if (magnitude > 0)
+	{
+		velocityX = (velocityX / magnitude) * 400.0f;
+		velocityY = (velocityY / magnitude) * 400.0f;
+	}
+
+	// Set the new cmd->forwardmove and cmd->sidemove to that vector
+	cmd->forwardmove = (short)velocityX;
+	cmd->sidemove = -1 * (short)velocityY; // sidemove points right, but positive velocityY points left.
+}

--- a/src/cl_input.c
+++ b/src/cl_input.c
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "input.h"
 #include "pmove.h"		// PM_FLY etc
 #include "rulesets.h"
+#include "cl_easyaircontrol.h"
 
 static void IN_AttackUp_CommonHide(void);
 
@@ -64,6 +65,7 @@ cvar_t cam_zoomaccel = { "cam_zoomaccel", "2000" };
 #endif
 
 extern cvar_t cl_independentPhysics;
+extern cvar_t cl_easyaircontrol;
 extern qbool physframe;
 extern double physframetime;
 
@@ -1091,6 +1093,9 @@ void CL_SendCmd(void)
 		Cam_Track(cmd);
 	}
 
+	if (cl_easyaircontrol.value && !(cl.onground))
+		CL_EasyAirControl(cmd);
+
 	CL_FinishMove(cmd);
 	cmdtime_msec += cmd->msec;
 
@@ -1305,6 +1310,7 @@ void CL_InitInput(void)
 	Cvar_Register(&cl_pitchspeed);
 	Cvar_Register(&cl_anglespeedkey);
 	Cvar_Register(&cl_iDrive);
+	Cvar_Register(&cl_easyaircontrol);
 
 	Cvar_SetCurrentGroup(CVAR_GROUP_INPUT_MISC);
 	Cvar_Register(&lookspring);


### PR DESCRIPTION
This code takes the user's held input and transforms it into something that redirects quake physics in the direction they are holding.  On a simple level, holding W and jumping around works just like CPMA.  

But it also allows you to smoothly cycle W > W+A > A > A+S > S > S+D > D > D+W > W and so on to bunny hop in circles while gaining speed, without having to turn your mouse.

The variable is configured to expect values of either 0 (off) or somewhere between 45-90.  62.5 seeems to be a sweet spot to use.  Also, you can change the variable freely and within aliases so that you can do something like this:

> alias +aircontrol "cl_easyaircontrol 62.5"
> alias -aircontrol "cl_easyaircontrol 0"
> bind shift +aircontrol

to make it so holding shift enables the easy air control mode. 