### PR TITLE
Add cl_allow_downloads

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1037,6 +1037,21 @@
         }
       ]
     },
+    "cl_allow_downloads": {
+      "default": "0",
+      "group-id": "9",
+      "type": "boolean",
+      "values": [
+        {
+          "description": "Don't allow downloads.",
+          "name": "0"
+        },
+        {
+          "description": "Allow downloads.",
+          "name": "1"
+        }
+      ]
+    },
     "cl_allow_remote_commands": {
       "default": "bf,changing,cmd ack,cmd new,cmd pext,cmd prespawn,cmd snap,cmd spawn,color,fullserverinfo,infoset,ktx_infoset,ktx_sinfoset,nextul,on_enter,on_enter_ctf,on_enter_ffa,on_spec_enter,on_spec_enter_ctf,on_spec_enter_ffa,packet,play,reconnect,say,sinfoset,skin,skins,team",
       "desc": "This variable controls which aliases and commands a remote server is allowed to execute on the client. Input a comma-separated list of commands to toggle access. The default values are adapted for KTX use.",

--- a/src/cl_cmd.c
+++ b/src/cl_cmd.c
@@ -653,6 +653,14 @@ void CL_Download_f (void){
 	char ondiskname[sizeof(cls.downloadname)]; // hack, save file to "right" place
 	extern char *CL_DemoDirectory(void);
 
+	extern cvar_t cl_allow_downloads;
+
+	if (!cl_allow_downloads.integer)
+	{
+		Com_Printf ("This command has been disabled for security reasons. Set cl_allow_downloads to 1 if you want to enable downloads.\n");
+		return;
+	}
+
 	if (cls.state == ca_disconnected) {
 		Com_Printf ("Must be connected.\n");
 		return;

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -304,6 +304,8 @@ cvar_t cl_allow_remote_commands = {
 	OnChange_allow_remote_commands
 };
 
+cvar_t cl_allow_downloads = { "cl_allow_downloads", "0" };
+
 /// persistent client state
 clientPersistent_t	cls;
 
@@ -2032,6 +2034,7 @@ static void CL_InitLocal(void)
 
 	// remote command execution restrictions
 	Cvar_Register(&cl_allow_remote_commands);
+	Cvar_Register(&cl_allow_downloads);
 
 	snprintf(st, sizeof(st), "ezQuake %i", REVISION);
 

--- a/src/cl_parse.c
+++ b/src/cl_parse.c
@@ -480,6 +480,13 @@ qbool CL_Download_Accept(const char *filename);
 // Returns true if the file exists, otherwise it attempts to start a download from the server.
 qbool CL_CheckOrDownloadFile(char *filename)
 {
+	extern cvar_t cl_allow_downloads;
+
+	if (!cl_allow_downloads.integer)
+	{
+		return true;
+	}
+
 	if (!CL_Download_Accept(filename))
 	{
 		return true;


### PR DESCRIPTION
By setting `cl_allow_downloads`, you can now control if the server should be allowed to upload files to your quake directory.

This configuration option also prevents you, the client, from using the `download` command to retrieve resources from the server.