### PR TITLE
Added Armor/Health to in-game autoID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ unezQuake has all of the latest ezQake features, plus:
  * `scr_autoid_ingame` - see autoID for teammates while playing
     * `scr_autoid_ingame_namelength`
     * `scr_autoid_ingame_weapon`
+    * `scr_autoid_ingame_armor_health`
  * `scr_scoreboard_showtracking` - see who spectators are following in the scoreboard (experimental)
     * `scr_scoreboard_showtracking_format`
     * `scr_scoreboard_showtracking_namewidth`

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -96,6 +96,9 @@ if [ $SKIP_DEPS -eq 0 ];then
 		manjaro)
 			install_check_arch
 			;;
+		archcraft)
+			install_check_arch
+			;;
 		void)
 			install_check_void
 			;;

--- a/help_variables.json
+++ b/help_variables.json
@@ -18421,6 +18421,12 @@
       "group-id": "40",
       "type": "integer"
     },
+    "scr_autoid_ingame_armor_health": {
+      "default": "1",
+      "desc": "Show armor and health in in-game teammate autoID.",
+      "group-id": "40",
+      "type": "integer"
+    },
     "scr_autoid_namelength": {
       "default": "0",
       "desc": "Maximum number of characters for autoID player names.",

--- a/src/hud_autoid.c
+++ b/src/hud_autoid.c
@@ -460,7 +460,8 @@ void SCR_DrawAutoID(void)
 			else if (currentlyplaying && ismyteam) {	// in-game stuff here
 				char *weap_str = "";
 				char weap_white_stripped[32];
-				
+				char armor_health_str[32];
+                char *aclr = "";
 				// Skip if not getting player updates, such as if teamoverlay is disabled
 				if (ti_cl->time && (ti_cl->time + TI_TIMEOUT >= r_refdef2.time)) {
 					if ((ti_cl->items & IT_ROCKET_LAUNCHER) && (ti_cl->items & IT_LIGHTNING))
@@ -469,7 +470,19 @@ void SCR_DrawAutoID(void)
 						weap_str = tp_name_lg.string;
 					else if (ti_cl->items & IT_ROCKET_LAUNCHER)
 						weap_str = tp_name_rl.string;
-				}
+                    
+                    if (ti_cl->items & IT_ARMOR3) {
+                        aclr = "&cf00";
+                    }
+                    else if (ti_cl->items & IT_ARMOR2) {
+                        aclr = "&cff0";
+                    }
+                    else if (ti_cl->items & IT_ARMOR1) {
+                        aclr = "&c0f0";
+                    }
+
+			        snprintf(armor_health_str, sizeof(armor_health_str), "%s%d/%s%s%d", aclr, ti_cl->armor, "&c", (ti_cl->health < 25 ? "f00" : (ti_cl->health > 100 ? "9cf" : "fff")), ti_cl->health);
+                }
 
 				Util_SkipChars(weap_str, "{}", weap_white_stripped, 32); // hide curly brackets
 
@@ -477,9 +490,9 @@ void SCR_DrawAutoID(void)
 				if (scr_autoid_ingame_namelength.integer >= 1 && scr_autoid_ingame_namelength.integer < MAX_SCOREBOARDNAME) {
 					name[scr_autoid_ingame_namelength.integer] = 0;
 				}
-
 				snprintf(tmp, sizeof(tmp), "%s %s", Player_StripNameColor(name), scr_autoid_ingame_weapon.integer ? weap_white_stripped : "");
-				Draw_SString(x - Draw_StringLengthColors(tmp, -1, 0.5 * scale, proportional), y - yoffset * scale, tmp, scale, proportional);
+                Draw_SString(x - Draw_StringLengthColors(armor_health_str, -1, 0.5 * scale, proportional), y - AUTOID_HEALTHBAR_OFFSET_Y * scale, armor_health_str, scale, proportional);
+                Draw_SString(x - Draw_StringLengthColors(tmp, -1, 0.5 * scale, proportional), y - yoffset * scale, tmp, scale, proportional);
 			}
 			else {	// demos, qtv, spectating
 				if (scr_autoid_namelength.integer >= 1 && scr_autoid_namelength.integer < MAX_SCOREBOARDNAME) {

--- a/src/hud_autoid.c
+++ b/src/hud_autoid.c
@@ -482,7 +482,7 @@ void SCR_DrawAutoID(void)
                         aclr = "&c0f0";
                     }
 
-			        snprintf(armor_health_str, sizeof(armor_health_str), "%s%d/%s%s%d", aclr, ti_cl->armor, "&c", (ti_cl->health < 25 ? "f00" : (ti_cl->health > 100 ? "9cf" : "fff")), ti_cl->health);
+			        snprintf(armor_health_str, sizeof(armor_health_str), "%s%d&cfff/%s%s%d", aclr, ti_cl->armor, "&c", (ti_cl->health < 25 ? "f00" : (ti_cl->health > 100 ? "9cf" : "fff")), ti_cl->health);
                 }
 
 				Util_SkipChars(weap_str, "{}", weap_white_stripped, 32); // hide curly brackets

--- a/src/hud_autoid.c
+++ b/src/hud_autoid.c
@@ -39,6 +39,7 @@ static cvar_t scr_autoid_scale                     = { "scr_autoid_scale", "1" }
 static cvar_t scr_autoid_ingame					   = { "scr_autoid_ingame", "0" };
 static cvar_t scr_autoid_ingame_namelength         = { "scr_autoid_ingame_namelength", "6" };
 static cvar_t scr_autoid_ingame_weapon         	   = { "scr_autoid_ingame_weapon", "1" };
+static cvar_t scr_autoid_ingame_armor_health	   = { "scr_autoid_ingame_armor_health", "1"};
 static cvar_t scr_autoid_yoffset		           = { "scr_autoid_yoffset", "0" };
 static cvar_t scr_autoid_proportional              = { "scr_autoid_proportional", "0" };
 
@@ -491,7 +492,9 @@ void SCR_DrawAutoID(void)
 					name[scr_autoid_ingame_namelength.integer] = 0;
 				}
 				snprintf(tmp, sizeof(tmp), "%s %s", Player_StripNameColor(name), scr_autoid_ingame_weapon.integer ? weap_white_stripped : "");
-                Draw_SString(x - Draw_StringLengthColors(armor_health_str, -1, 0.5 * scale, proportional), y - AUTOID_HEALTHBAR_OFFSET_Y * scale, armor_health_str, scale, proportional);
+				if (scr_autoid_ingame_armor_health.integer) {
+					Draw_SString(x - Draw_StringLengthColors(armor_health_str, -1, 0.5 * scale, proportional), y - AUTOID_HEALTHBAR_OFFSET_Y * scale, armor_health_str, scale, proportional);
+				}
                 Draw_SString(x - Draw_StringLengthColors(tmp, -1, 0.5 * scale, proportional), y - yoffset * scale, tmp, scale, proportional);
 			}
 			else {	// demos, qtv, spectating
@@ -525,6 +528,7 @@ void SCR_RegisterAutoIDCvars(void)
 		Cvar_Register(&scr_autoid_ingame);
 		Cvar_Register(&scr_autoid_ingame_namelength);
 		Cvar_Register(&scr_autoid_ingame_weapon);
+		Cvar_Register(&scr_autoid_ingame_armor_health);
 		Cvar_Register(&scr_autoid_yoffset);
 		Cvar_Register(&scr_autoid_healthbar_bg_color);
 		Cvar_Register(&scr_autoid_healthbar_normal_color);


### PR DESCRIPTION
Put a text based Armor/Health element with the same coloring pattern as overlay for in-game autoID.
Added a new cvar scr_autoid_ingame_armor_health to toggle on or off, similar to how it works for weapon.

Only thing that may need additional changing is the low health and mega health colors are hard coded right now because I was unsure on the best way to reference those values from the teaminfo hud element.