### PR TITLE
Execute TP triggers in the appropriate context

### DIFF
--- a/src/tp_triggers.c
+++ b/src/tp_triggers.c
@@ -132,7 +132,8 @@ void TP_ExecTrigger (const char *trigger)
  
 	if ((alias = Cmd_FindAlias (trigger))) {
 		if (!(f_triggers[i].restricted && Rulesets_RestrictTriggers ())) {
-			Cbuf_AddTextEx (&cbuf_main, va("%s\n", alias->value));
+			Cbuf_AddTextEx(alias->flags & ALIAS_SERVER ? &cbuf_svc : &cbuf_main,
+				va("%s\n", alias->value));
 		}
 	}
 }


### PR DESCRIPTION
A malicious proxy or server can inject a f_trigger alias that gets executed in the cbuf main context, effectively circumventing the remote capabilities check and enabling remote code execution.

This fix checks whether the alias was submitted by a server, and if so, executes it in the server context instead.