### PR TITLE
Add hud_total_strength

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,7 @@ set(common_hud
         ${SOURCE_DIR}/hud_groups.c
         ${SOURCE_DIR}/hud_guns.c
         ${SOURCE_DIR}/hud_health.c
+        ${SOURCE_DIR}/hud_total_strength.c
         ${SOURCE_DIR}/hud_inlay.c
         ${SOURCE_DIR}/hud_items.c
         ${SOURCE_DIR}/hud_net.c

--- a/src/hud_common.c
+++ b/src/hud_common.c
@@ -70,6 +70,7 @@ void Guns_HudInit(void);
 void Groups_HudInit(void);
 void Armor_HudInit(void);
 void Health_HudInit(void);
+void TotalStrength_HudInit(void);
 void GameSummary_HudInit(void);
 void Performance_HudInit(void);
 void Scores_HudInit(void);
@@ -1031,6 +1032,7 @@ void CommonDraw_Init(void)
     Inlay_HudInit();
 	TeamHold_HudInit();
 	Health_HudInit();
+        TotalStrength_HudInit();
 	Frags_HudInit();
 	Tracking_HudInit();
 	CenterPrint_HudInit();

--- a/src/hud_total_strength.c
+++ b/src/hud_total_strength.c
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2011 azazello and ezQuake team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "quakedef.h"
+#include "common_draw.h"
+#include "hud.h"
+#include "hud_common.h"
+#include "vx_stuff.h"
+
+static int TP_IsHealthLowForTotalStrength(void)
+{
+	extern cvar_t tp_need_health;
+
+	return cl.stats[STAT_HEALTH] <= tp_need_health.value;
+}
+
+static qbool HUD_HealthLowForTotalStrength(void)
+{
+	extern cvar_t hud_tp_need;
+
+	if (hud_tp_need.value) {
+		return TP_IsHealthLowForTotalStrength();
+	}
+	else {
+		return HUD_Stats(STAT_HEALTH) <= 25;
+	}
+}
+
+static void SCR_HUD_DrawTotalStrength(hud_t *hud)
+{
+	static cvar_t *scale = NULL, *style, *digits, *align, *proportional;
+	static int value;
+	if (scale == NULL) {
+		// first time called
+		scale = HUD_FindVar(hud, "scale");
+		style = HUD_FindVar(hud, "style");
+		digits = HUD_FindVar(hud, "digits");
+		align = HUD_FindVar(hud, "align");
+		proportional = HUD_FindVar(hud, "proportional");
+	}
+
+        value = SCR_HUD_TotalStrength(HUD_Stats(STAT_HEALTH),HUD_Stats(STAT_ARMOR), SCR_HUD_ArmorType(HUD_Stats(STAT_ITEMS)));
+	if (cl.spectator == cl.autocam) {
+		SCR_HUD_DrawNum(hud, (value < 0 ? 0 : value), HUD_HealthLowForTotalStrength(), scale->value, style->value, digits->value, align->string, proportional->integer);
+	}
+}
+
+
+void TotalStrength_HudInit(void)
+{
+	// Total strength
+	HUD_Register(
+		"totalstrength", NULL, "Part of your status - total strength level.",
+		HUD_INVENTORY, ca_active, 0, SCR_HUD_DrawTotalStrength,
+		"0", "screen", "left", "top", "0", "0", "0", "0 0 0", NULL,
+		"style", "0",
+		"scale", "1",
+		"align", "right",
+		"digits", "3",
+		"proportional", "0",
+		NULL
+	);
+
+}


### PR DESCRIPTION
With new hud (scr_newhud 1 or 2) and hud_totalstrength_show 1 it shows total player strength calculated by SCR_HUD_TotalStrength as a number. Such strength takes into account armor amount and damage absorption plus available health.