### PR TITLE
Add cl_debug_antilag_projection

### DIFF
--- a/help_variables.json
+++ b/help_variables.json
@@ -1418,6 +1418,12 @@
       "group-id": "21",
       "type": "boolean"
     },
+    "cl_debug_antilag_projection": {
+      "default": "0",
+      "desc": "Prints rocket spawn position deltas to the console on each new server projectile: the offset from the expected spawn point, and (if client-side projectile prediction is enabled) the offset from the predicted client-side position.",
+      "group-id": "21",
+      "type": "boolean"
+    },
     "cl_debug_antilag_self": {
       "default": "0",
       "desc": "Chooses whether to include the currently tracked player in antilag debugging.",

--- a/src/cl_ents.c
+++ b/src/cl_ents.c
@@ -31,6 +31,7 @@ static int MVD_TranslateFlags(int src);
 void TP_ParsePlayerInfo(player_state_t *, player_state_t *, player_info_t *info);	
 
 extern cvar_t cl_predict_players, cl_solid_players, cl_rocket2grenade;
+extern cvar_t cl_debug_antilag_projection;
 extern cvar_t cl_predict_half, cl_predict_scale, cl_predict_lerp;
 extern cvar_t cl_predict_scale_threshold;
 extern cvar_t cl_predict_show_errors;
@@ -647,8 +648,47 @@ void FlushEntityPacket (void) {
 	}
 }
 
+static void CL_DebugAntilagProjection(vec3_t origin, vec3_t forward, vec3_t cs_proj_origin)
+{
+	int i, best = -1;
+	float best_dist = 1e30f;
+
+	// Find nearest player to the origin
+	for (i = 0; i < MAX_CLIENTS; i++) {
+		player_state_t *ps = &cl.frames[cl.parsecountmod].playerstate[i];
+		if (!cl.players[i].name[0] || cl.players[i].spectator || !ps->modelindex)
+			continue;
+		vec3_t diff;
+		VectorSubtract(origin, ps->origin, diff);
+		float d = VectorLength(diff);
+		if (d < best_dist) { best_dist = d; best = i; }
+	}
+
+	if (best < 0) {
+		Con_Printf("antilag debug: no active players\n");
+		return;
+	}
+
+	// Compute expected rocket position based on ktx mod code
+	player_state_t *ps = &cl.frames[cl.parsecountmod].playerstate[best];
+	vec3_t expected, diff;
+	expected[0] = ps->origin[0] + forward[0] * 8;
+	expected[1] = ps->origin[1] + forward[1] * 8;
+	expected[2] = ps->origin[2] + forward[2] * 8 + 16;
+	VectorSubtract(origin, expected, diff);
+
+	// Additionally, if we have a client side projectile, include the delta between it and the server side projectile
+	if (cs_proj_origin) {
+		vec3_t cs_diff;
+		VectorSubtract(origin, cs_proj_origin, cs_diff);
+		Con_Printf("antilag debug deltas: spawn: %.1fu client: %.1fu\n", VectorLength(diff), VectorLength(cs_diff));
+	} else {
+		Con_Printf("antilag debug deltas: spawn: %.1f client: disabled\n", VectorLength(diff));
+	}
+}
+
 // An svc_packetentities has just been parsed, deal with the rest of the data stream.
-void CL_ParsePacketEntities (qbool delta) 
+void CL_ParsePacketEntities (qbool delta)
 {
 	int oldpacket, newpacket, oldindex, newindex, word, newnum, oldnum;
 	packet_entities_t *oldp, *newp, dummy;
@@ -822,7 +862,16 @@ void CL_ParsePacketEntities (qbool delta)
 				Host_Error ("CL_ParsePacketEntities: newindex == MAX_PACKET_ENTITIES");
 
 			CL_ParseDelta (&cl_entities[newnum].baseline, &newp->entities[newindex], word);
-			CL_SetupPacketEntity (newnum, &newp->entities[newindex], word > 511); 
+			if (cl_debug_antilag_projection.value) {
+				int idx = newp->entities[newindex].modelindex;
+				if (idx == cl_modelindices[mi_rocket]
+						&& cl.validsequence - cl_entities[newnum].sequence > 2) {
+					vec3_t fwd;
+					AngleVectors(newp->entities[newindex].angles, fwd, NULL, NULL);
+					CL_DebugAntilagProjection(newp->entities[newindex].origin, fwd, NULL);
+				}
+			}
+			CL_SetupPacketEntity (newnum, &newp->entities[newindex], word > 511);
 			newindex++;
 			continue;
 		}
@@ -1143,6 +1192,19 @@ void CL_ParsePacketSimpleProjectiles(void)
 		{
 			cs_sproj->fproj_number = -1;
 			cs_sproj->fproj_number = CL_SimpleProjectile_MatchFakeProj(cs_sproj, word);
+
+			if (cl_debug_antilag_projection.value && cs_sproj->modelindex == cl_modelindices[mi_rocket]) {
+				vec3_t fwd;
+				float speed = VectorLength(cs_sproj->velocity);
+				if (speed > 0) {
+					VectorScale(cs_sproj->velocity, 1.0f / speed, fwd);
+				} else {
+					AngleVectors(cs_sproj->angles, fwd, NULL, NULL);
+				}
+				float *cs_origin = (cs_sproj->fproj_number >= 0) ? cl_fakeprojectiles[cs_sproj->fproj_number].org : NULL;
+				CL_DebugAntilagProjection(cs_sproj->origin, fwd, cs_origin);
+			}
+
 			if (cs_sproj->fproj_number < 0)
 			{
 				mis_new = 2;

--- a/src/cl_main.c
+++ b/src/cl_main.c
@@ -285,11 +285,12 @@ cvar_t cl_username              = {"cl_username", "", CVAR_QUEUED_TRIGGER, AuthU
 static void CL_Authenticate_f(void);
 
 // antilag debugging
-cvar_t cl_debug_antilag_view    = { "cl_debug_antilag_view", "0" };
-cvar_t cl_debug_antilag_ghost   = { "cl_debug_antilag_ghost", "0" };
-cvar_t cl_debug_antilag_self    = { "cl_debug_antilag_self", "0" };
-cvar_t cl_debug_antilag_lines   = { "cl_debug_antilag_lines", "0" };
-cvar_t cl_debug_antilag_send    = { "cl_debug_antilag_send", "0" };
+cvar_t cl_debug_antilag_view       = { "cl_debug_antilag_view", "0" };
+cvar_t cl_debug_antilag_ghost      = { "cl_debug_antilag_ghost", "0" };
+cvar_t cl_debug_antilag_self       = { "cl_debug_antilag_self", "0" };
+cvar_t cl_debug_antilag_lines      = { "cl_debug_antilag_lines", "0" };
+cvar_t cl_debug_antilag_send       = { "cl_debug_antilag_send", "0" };
+cvar_t cl_debug_antilag_projection = { "cl_debug_antilag_projection", "0" };
 
 // weapon-switching debugging
 cvar_t cl_debug_weapon_view     = { "cl_debug_weapon_view", "0" };
@@ -2025,6 +2026,7 @@ static void CL_InitLocal(void)
 	Cvar_Register(&cl_debug_antilag_self);
 	Cvar_Register(&cl_debug_antilag_lines);
 	Cvar_Register(&cl_debug_antilag_send);
+	Cvar_Register(&cl_debug_antilag_projection);
 
 	// debugging weapons
 	Cvar_Register(&cl_debug_weapon_view);


### PR DESCRIPTION
Add a debug antilag projection cvar to print to the console the delta distance between the expected origin on a rocket (per game/ktx code) and its actual position the first time we see it. Additionally, if projectile prediction is enabled, also show the delta distance for the client side rocket. 

In most cases, if a player is not moving, this will always be 50 / disabled for sv_antilag 2, and dependent upon ping / a low value for sv_antilag 1. 